### PR TITLE
Stream Deck Neo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ But as it stands, this library should support following devices:
 - Stream Deck Mini
 - Stream Deck Mini Mk2
 - Stream Deck Mk2
-- Stream Deck Neo
 - Stream Deck Pedal
 - Stream Deck Plus (thanks to [node-elgato-stream-deck](https://github.com/Julusian/node-elgato-stream-deck))
-
+- Stream Deck Neo (thanks to [@ejiektpobehuk](https://github.com/ejiektpobehuk), [@AkechiShiro](https://github.com/AkechiShiro) and [node-elgato-stream-deck](https://github.com/Julusian/node-elgato-stream-deck))
 - Ajazz AKP153

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ But as it stands, this library should support following devices:
 - Stream Deck Mini
 - Stream Deck Mini Mk2
 - Stream Deck Mk2
+- Stream Deck Neo
 - Stream Deck Pedal
 - Stream Deck Plus (thanks to [node-elgato-stream-deck](https://github.com/Julusian/node-elgato-stream-deck))
 

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -34,15 +34,15 @@ async fn main() {
                     device.set_button_image(i, image.clone()).unwrap();
                 }
 
-                println!("Touch point count: {}", kind.point_count());
-                for i in 0..kind.point_count() as u8 {
-                    device.set_touch_point_color(i, 255, 255, 255).unwrap();
+                println!("Touch point count: {}", kind.touchpoint_count());
+                for i in 0..kind.touchpoint_count() as u8 {
+                    device.set_touchpoint_color(i, 255, 255, 255).unwrap();
                 }
 
                 match device.kind().lcd_strip_size() {
                     Some((x, y)) => {
                         let strip_image = ImageRect::from_image(image.clone().resize_to_fill(x as u32, y as u32, image::imageops::FilterType::Nearest)).unwrap();
-                        device.write_lcd(x as u16, y as u16, &strip_image);
+                        let _ = device.write_lcd(0, 0, &strip_image);
                     }
                     None => (),
                 }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -116,7 +116,7 @@ async fn main() {
                     drop(reader);
                 }
 
-                device.shutdown().unwrap();
+                device.shutdown().ok();
             }
         }
         Err(e) => eprintln!("Failed to create HidApi instance: {}", e),

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use elgato_streamdeck::{list_devices, new_hidapi, DeviceStateUpdate, StreamDeck};
+use elgato_streamdeck::{images::ImageRect, list_devices, new_hidapi, DeviceStateUpdate, StreamDeck};
 use image::open;
 
 #[tokio::main]
@@ -37,6 +37,14 @@ async fn main() {
                 println!("Touch point count: {}", kind.point_count());
                 for i in 0..kind.point_count() as u8 {
                     device.set_touch_point_color(i, 255, 255, 255).unwrap();
+                }
+
+                match device.kind().lcd_strip_size() {
+                    Some((x, y)) => {
+                        let strip_image = ImageRect::from_image(image.clone().resize_to_fill(x as u32, y as u32, image::imageops::FilterType::Nearest)).unwrap();
+                        device.write_lcd(x as u16, y as u16, &strip_image);
+                    }
+                    None => (),
                 }
 
                 // Flush

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -34,6 +34,11 @@ async fn main() {
                     device.set_button_image(i, image.clone()).unwrap();
                 }
 
+                println!("Touch point count: {}", kind.point_count());
+                for i in 0..kind.point_count() as u8 {
+                    device.set_touch_point_color(i, 255, 255, 255).unwrap();
+                }
+
                 // Flush
                 if device.is_updated() {
                     device.flush().unwrap();
@@ -67,6 +72,13 @@ async fn main() {
                                 }
                                 DeviceStateUpdate::EncoderUp(dial) => {
                                     println!("Dial {} up", dial);
+                                }
+
+                                DeviceStateUpdate::TouchPointDown(point) => {
+                                    println!("Touch point {} down", point);
+                                }
+                                DeviceStateUpdate::TouchPointUp(point) => {
+                                    println!("Touch point {} up", point);
                                 }
 
                                 DeviceStateUpdate::TouchScreenPress(x, y) => {

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -104,7 +104,7 @@ impl AsyncStreamDeck {
         Arc::new(AsyncDeviceStateReader {
             device: self.clone(),
             states: Mutex::new(DeviceState {
-                buttons: vec![false; self.kind.key_count() as usize + self.kind.touchpoint_count()],
+                buttons: vec![false; self.kind.key_count() as usize + self.kind.touchpoint_count() as usize],
                 encoders: vec![false; self.kind.encoder_count() as usize],
             }),
         })
@@ -175,7 +175,7 @@ impl AsyncStreamDeck {
     /// Sets specified touch point's led strip color
     pub async fn set_touchpoint_color(&mut self, point: u8, red: u8, green: u8, blue: u8) -> Result<(), StreamDeckError> {
         let device = self.device.clone();
-        let lock = device.lock().await;
+        let mut lock = device.lock().await;
         Ok(block_in_place(move || lock.set_touchpoint_color(point, red, green, blue))?)
     }
 }

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -124,21 +124,22 @@ impl AsyncStreamDeck {
         Ok(block_in_place(move || lock.set_brightness(percent))?)
     }
 
-    /// Writes image data to Stream Deck device, needs to accept Arc for image data since it runs a blocking thread under the hood
+    /// Writes image data to Stream Deck device
     pub async fn write_image(&self, key: u8, image_data: &[u8]) -> Result<(), StreamDeckError> {
         let device = self.device.clone();
         let mut lock = device.lock().await;
         Ok(block_in_place(move || lock.write_image(key, image_data))?)
     }
 
-    /// Writes image data to Stream Deck device's lcd strip/screen, needs to accept Arc for image data since it runs a blocking thread under the hood
+    /// Writes image data to Stream Deck device's lcd strip/screen as region. 
+    /// Only Stream Deck Plus supports writing LCD regions, for Stream Deck Neo use write_lcd_fill
     pub async fn write_lcd(&self, x: u16, y: u16, rect: &ImageRect) -> Result<(), StreamDeckError> {
         let device = self.device.clone();
         let lock = device.lock().await;
         Ok(block_in_place(move || lock.write_lcd(x, y, rect))?)
     }
 
-    /// Writes image data to Stream Deck device's lcd strip/screen, needs to accept Arc for image data since it runs a blocking thread under the hood
+    /// Writes image data to Stream Deck device's lcd strip/screen as full fill
     pub async fn write_lcd_fill(&self, image_data: &[u8]) -> Result<(), StreamDeckError> {
         let device = self.device.clone();
         let lock = device.lock().await;

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -104,7 +104,7 @@ impl AsyncStreamDeck {
         Arc::new(AsyncDeviceStateReader {
             device: self.clone(),
             states: Mutex::new(DeviceState {
-                buttons: vec![false; self.kind.key_count() as usize],
+                buttons: vec![false; self.kind.key_count() as usize + self.kind.touchpoint_count()],
                 encoders: vec![false; self.kind.encoder_count() as usize],
             }),
         })
@@ -166,10 +166,10 @@ impl AsyncStreamDeck {
     }
 
     /// Sets specified touch point's led strip color
-    pub async fn set_touch_point_color(&mut self, point: u8, red: u8, green: u8, blue: u8) -> Result<(), StreamDeckError> {
+    pub async fn set_touchpoint_color(&mut self, point: u8, red: u8, green: u8, blue: u8) -> Result<(), StreamDeckError> {
         let device = self.device.clone();
         let lock = device.lock().await;
-        Ok(block_in_place(move || lock.set_touch_point_color(point, red, green, blue))?)
+        Ok(block_in_place(move || lock.set_touchpoint_color(point, red, green, blue))?)
     }
 }
 

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -164,6 +164,13 @@ impl AsyncStreamDeck {
         let mut lock = device.lock().await;
         Ok(block_in_place(move || lock.write_image(key, &image))?)
     }
+
+    /// Sets specified touch point's led strip color
+    pub async fn set_touch_point_color(&mut self, point: u8, red: u8, green: u8, blue: u8) -> Result<(), StreamDeckError> {
+        let device = self.device.clone();
+        let lock = device.lock().await;
+        Ok(block_in_place(move || lock.set_touch_point_color(point, red, green, blue))?)
+    }
 }
 
 /// Button reader that keeps state of the Stream Deck and returns events instead of full states
@@ -193,10 +200,18 @@ impl AsyncDeviceStateReader {
                         }
                         _ => {
                             if *their != *mine {
-                                if *their {
-                                    updates.push(DeviceStateUpdate::ButtonDown(index as u8));
+                                if index < self.device.kind.key_count() as usize {
+                                    if *their {
+                                        updates.push(DeviceStateUpdate::ButtonDown(index as u8));
+                                    } else {
+                                        updates.push(DeviceStateUpdate::ButtonUp(index as u8));
+                                    }
                                 } else {
-                                    updates.push(DeviceStateUpdate::ButtonUp(index as u8));
+                                    if *their {
+                                        updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - self.device.kind.key_count()));
+                                    } else {
+                                        updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - self.device.kind.key_count()));
+                                    }
                                 }
                             }
                         }

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -140,6 +140,13 @@ impl AsyncStreamDeck {
     }
 
     /// Writes image data to Stream Deck device's lcd strip/screen as full fill
+    ///
+    /// You can convert your images into proper image_data like this:
+    /// ```
+    /// use elgato_streamdeck::images::{convert_image_with_format_async};
+    /// let image_data = convert_image_with_format_async(device.kind().lcd_image_format(), image).await.unwrap();
+    /// device.write_lcd_fill(&image_data).await;
+    /// ```
     pub async fn write_lcd_fill(&self, image_data: &[u8]) -> Result<(), StreamDeckError> {
         let device = self.device.clone();
         let lock = device.lock().await;

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -138,6 +138,13 @@ impl AsyncStreamDeck {
         Ok(block_in_place(move || lock.write_lcd(x, y, rect))?)
     }
 
+    /// Writes image data to Stream Deck device's lcd strip/screen, needs to accept Arc for image data since it runs a blocking thread under the hood
+    pub async fn write_lcd_fill(&self, image_data: &[u8]) -> Result<(), StreamDeckError> {
+        let device = self.device.clone();
+        let lock = device.lock().await;
+        Ok(block_in_place(move || lock.write_lcd_fill(image_data))?)
+    }
+
     /// Sets button's image to blank
     pub async fn clear_button_image(&self, key: u8) -> Result<(), StreamDeckError> {
         let image = self.kind.blank_image();

--- a/src/images.rs
+++ b/src/images.rs
@@ -6,12 +6,15 @@ use image::codecs::jpeg::JpegEncoder;
 use image::imageops::FilterType;
 
 use crate::{Kind, StreamDeckError};
-use crate::info::{ImageMirroring, ImageMode, ImageRotation};
+use crate::info::{ImageFormat, ImageMirroring, ImageMode, ImageRotation};
 
 /// Converts image into image data depending on provided kind of device
 pub fn convert_image(kind: Kind, image: DynamicImage) -> Result<Vec<u8>, ImageError> {
-    let image_format = kind.key_image_format();
+    convert_image_with_format(kind.key_image_format(), image)
+}
 
+/// Converts image into image data depending on provided image format
+pub fn convert_image_with_format(image_format: ImageFormat, image: DynamicImage) -> Result<Vec<u8>, ImageError> {
     // Ensuring size of the image
     let (ws, hs) = image_format.size;
 
@@ -56,8 +59,15 @@ pub fn convert_image(kind: Kind, image: DynamicImage) -> Result<Vec<u8>, ImageEr
 /// Converts image into image data depending on provided kind of device, can be safely ran inside [multi_thread](tokio::runtime::Builder::new_multi_thread) runtime
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-pub fn convert_image_async(kind: Kind, image: DynamicImage) -> Result<Vec<u8>, crate::StreamDeckError> {
+pub fn convert_image_async(kind: Kind, image: DynamicImage) -> Result<Vec<u8>, StreamDeckError> {
     Ok(tokio::task::block_in_place(move || convert_image(kind, image))?)
+}
+
+/// Converts image into image data depending on provided image format, can be safely ran inside [multi_thread](tokio::runtime::Builder::new_multi_thread) runtime
+#[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+pub fn convert_image_with_format_async(format: ImageFormat, image: DynamicImage) -> Result<Vec<u8>, StreamDeckError> {
+    Ok(tokio::task::block_in_place(move || convert_image_with_format(format, image))?)
 }
 
 /// Rect to be used when trying to send image to lcd screen

--- a/src/info.rs
+++ b/src/info.rs
@@ -15,6 +15,8 @@ pub const PID_STREAMDECK_XL_V2: u16 = 0x008f;
 pub const PID_STREAMDECK_MK2: u16 = 0x0080;
 /// Product ID of Stream Deck Mini Mk2
 pub const PID_STREAMDECK_MINI_MK2: u16 = 0x0090;
+/// Product ID of Stream Deck Neo
+pub const PID_STREAMDECK_NEO: u16 = 0x009a;
 /// Product ID of Stream Deck Pedal
 pub const PID_STREAMDECK_PEDAL: u16 = 0x0086;
 /// Product ID of Stream Deck Plus
@@ -43,6 +45,8 @@ pub enum Kind {
     Mk2,
     /// Stream Deck Mini Mk2
     MiniMk2,
+    /// Stream Deck Neo
+    Neo,
     /// Stream Deck Pedal
     Pedal,
     /// Stream Deck Plus
@@ -62,6 +66,7 @@ impl Kind {
             PID_STREAMDECK_XL_V2 => Some(Kind::XlV2),
             PID_STREAMDECK_MK2 => Some(Kind::Mk2),
             PID_STREAMDECK_MINI_MK2 => Some(Kind::MiniMk2),
+            PID_STREAMDECK_NEO => Some(Kind::Neo),
             PID_STREAMDECK_PEDAL => Some(Kind::Pedal),
             PID_STREAMDECK_PLUS => Some(Kind::Plus),
             PID_AJAZZ_AKP153 => Some(Kind::Akp153),
@@ -79,6 +84,7 @@ impl Kind {
             Kind::XlV2 => PID_STREAMDECK_XL_V2,
             Kind::Mk2 => PID_STREAMDECK_MK2,
             Kind::MiniMk2 => PID_STREAMDECK_MINI_MK2,
+            Kind::Neo => PID_STREAMDECK_NEO,
             Kind::Pedal => PID_STREAMDECK_PEDAL,
             Kind::Plus => PID_STREAMDECK_PLUS,
             Kind::Akp153 => PID_AJAZZ_AKP153,
@@ -95,6 +101,7 @@ impl Kind {
             Kind::XlV2 => ELGATO_VENDOR_ID,
             Kind::Mk2 => ELGATO_VENDOR_ID,
             Kind::MiniMk2 => ELGATO_VENDOR_ID,
+            Kind::Neo => ELGATO_VENDOR_ID,
             Kind::Pedal => ELGATO_VENDOR_ID,
             Kind::Plus => ELGATO_VENDOR_ID,
             Kind::Akp153 => AJAZZ_VENDOR_ID,
@@ -108,7 +115,7 @@ impl Kind {
             Kind::Mini | Kind::MiniMk2 => 6,
             Kind::Xl | Kind::XlV2 => 32,
             Kind::Pedal => 3,
-            Kind::Plus => 8,
+            Kind::Neo | Kind::Plus => 8,
             Kind::Akp153 => 15 + 3,
         }
     }
@@ -120,7 +127,7 @@ impl Kind {
             Kind::Mini | Kind::MiniMk2 => 2,
             Kind::Xl | Kind::XlV2 => 4,
             Kind::Pedal => 1,
-            Kind::Plus => 2,
+            Kind::Neo | Kind::Plus => 2,
             Kind::Akp153 => 3,
         }
     }
@@ -132,7 +139,7 @@ impl Kind {
             Kind::Mini | Kind::MiniMk2 => 3,
             Kind::Xl | Kind::XlV2 => 8,
             Kind::Pedal => 3,
-            Kind::Plus => 4,
+            Kind::Neo | Kind::Plus => 4,
             Kind::Akp153 => 6,
         }
     }
@@ -145,10 +152,19 @@ impl Kind {
         }
     }
 
+    /// Amount of touch points the Stream Deck kind has
+    pub fn point_count(&self) -> u8 {
+        match self {
+            Kind::Neo => 2,
+            _ => 0,
+        }
+    }
+
     /// Size of the LCD strip on the device
     pub fn lcd_strip_size(&self) -> Option<(usize, usize)> {
         match self {
             Kind::Plus => Some((800, 100)),
+            Kind::Neo => Some((248, 58)),
             Kind::Akp153 => Some((854, 480)), // logo
             _ => None,
         }
@@ -191,7 +207,7 @@ impl Kind {
                 mirror: ImageMirroring::Y,
             },
 
-            Kind::Xl | Kind::XlV2 => ImageFormat {
+            Kind::Neo | Kind::Xl | Kind::XlV2 => ImageFormat {
                 mode: ImageMode::JPEG,
                 size: (96, 96),
                 rotation: ImageRotation::Rot0,
@@ -260,7 +276,7 @@ impl Kind {
                 0x02, 0x8a, 0x28, 0xa0, 0x0f, 0xff, 0xd9,
             ],
 
-            Kind::Xl | Kind::XlV2 => vec![
+            Kind::Neo | Kind::Xl | Kind::XlV2 => vec![
                 0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06,
                 0x05, 0x08, 0x07, 0x07, 0x07, 0x09, 0x09, 0x08, 0x0a, 0x0c, 0x14, 0x0d, 0x0c, 0x0b, 0x0b, 0x0c, 0x19, 0x12, 0x13, 0x0f, 0x14, 0x1d, 0x1a, 0x1f, 0x1e, 0x1d, 0x1a, 0x1c, 0x1c, 0x20,
                 0x24, 0x2e, 0x27, 0x20, 0x22, 0x2c, 0x23, 0x1c, 0x1c, 0x28, 0x37, 0x29, 0x2c, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1f, 0x27, 0x39, 0x3d, 0x38, 0x32, 0x3c, 0x2e, 0x33, 0x34, 0x32, 0xff,

--- a/src/info.rs
+++ b/src/info.rs
@@ -231,6 +231,25 @@ impl Kind {
             },
         }
     }
+    
+    /// Image format used by LCD screen, used for filling LCD
+    pub fn lcd_image_format(&self) -> Option<ImageFormat> {
+        match self {
+            Kind::Neo => Some(ImageFormat {
+                mode: ImageMode::JPEG,
+                size: (248, 58),
+                rotation: ImageRotation::Rot0,
+                mirror: ImageMirroring::None,
+            }),
+            Kind::Plus => Some(ImageFormat {
+                mode: ImageMode::JPEG,
+                size: (800, 100),
+                rotation: ImageRotation::Rot0,
+                mirror: ImageMirroring::None,
+            }),
+            _ => None
+        }
+    }
 
     /// Returns blank image data appropriate for the Stream Deck kind
     pub fn blank_image(&self) -> Vec<u8> {

--- a/src/info.rs
+++ b/src/info.rs
@@ -153,7 +153,7 @@ impl Kind {
     }
 
     /// Amount of touch points the Stream Deck kind has
-    pub fn point_count(&self) -> u8 {
+    pub fn touchpoint_count(&self) -> u8 {
         match self {
             Kind::Neo => 2,
             _ => 0,

--- a/src/info.rs
+++ b/src/info.rs
@@ -238,7 +238,7 @@ impl Kind {
             Kind::Neo => Some(ImageFormat {
                 mode: ImageMode::JPEG,
                 size: (248, 58),
-                rotation: ImageRotation::Rot0,
+                rotation: ImageRotation::Rot180,
                 mirror: ImageMirroring::None,
             }),
             Kind::Plus => Some(ImageFormat {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,8 +494,8 @@ impl StreamDeck {
                         if last_package { 1 } else { 0 },
                         (this_length & 0xff) as u8,
                         (this_length >> 8) as u8,
-                        ((page_number + 1) & 0xff) as u8,
-                        ((page_number + 1) >> 8) as u8,
+                        (page_number & 0xff) as u8,
+                        (page_number >> 8) as u8,
                     ]
                 )
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,14 @@ impl StreamDeck {
         )
     }
 
-    /// Writes image data to Stream Deck device's lcd strip/screen as full fill 
+    /// Writes image data to Stream Deck device's lcd strip/screen as full fill
+    /// 
+    /// You can convert your images into proper image_data like this:
+    /// ```
+    /// use elgato_streamdeck::images::convert_image_with_format;
+    /// let image_data = convert_image_with_format(device.kind().lcd_image_format(), image).unwrap();
+    /// device.write_lcd_fill(&image_data);
+    /// ```
     pub fn write_lcd_fill(&self, image_data: &[u8]) -> Result<(), StreamDeckError> {
         match self.kind {
             Kind::Neo => {


### PR DESCRIPTION
A draft of Stream Deck Neo support inspired by [Julusian/node-elgato-stream-deck](https://github.com/Julusian/node-elgato-stream-deck). If this one goes well, it supersedes #9 and closes #7

Stream Deck Neo has new ways of input and output.

**Two capacitive buttons** that have physical dots to help users find them.
On the device official page they are called "Touch Points" so that's the name I'm sticking with.

Each of them has a dedicated **led strip** that can output an RGB color.

On the device Touch Points have indexes that follow regular key indexes.
I'm hiding this fact in the library API, so it looks like they have their own indexing.
This is the part I'm still figuring out.

There are new events for Touch Points that are separate from regular buttons. `TouchPointDown` and `TouchPointUp`. And there is a new function to set the color of the LED strips - `set_touch_point_color`.

Unfortunately, I don't have a device so I'm hoping for help from someone with the device. [@AkechiShiro](https://github.com/AkechiShiro) was kind enough to offer some help. Thanks in advance!

Ps. Am I correct about the the LCD screen not being touch capable?

____

Implementation roadmap

- [x] Buttons
  - [x] Shows images
  - [x] Register input
- [ ] LCD outputs images
- [x] Touch points
  - [x] Sets the led color
  - [x] Index validation
  - [x] Registers input
- [x] Async Wrapper
