### PR TITLE
Remove check of serial number for devices with corrupted firmware

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,6 @@ pub fn list_devices(hidapi: &HidApi) -> Vec<(Kind, String)> {
             }
 
             if let Some(serial) = d.serial_number() {
-                if !serial.chars().all(|c| c.is_alphanumeric()) {
-                    return None;
-                }
-
                 Some((Kind::from_pid(d.product_id())?, serial.to_string()))
             } else {
                 None


### PR DESCRIPTION
This is a followup of issue https://github.com/streamduck-org/elgato-streamdeck/issues/16