### PR TITLE
Support of Ajazz Akp815 device

### DIFF
--- a/40-streamdeck.rules
+++ b/40-streamdeck.rules
@@ -9,6 +9,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0086", MODE="0660", 
 SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE="0660", GROUP="plugdev"
@@ -22,6 +23,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0060", MODE="0660", GROUP="plugdev"
@@ -35,6 +37,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE="0660", GROUP="plugdev"
@@ -48,4 +51,5 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", GROUP="plugdev"

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ But as it stands, this library should support following devices:
 - Stream Deck Neo (thanks to [@ejiektpobehuk](https://github.com/ejiektpobehuk), [@AkechiShiro](https://github.com/AkechiShiro) and [node-elgato-stream-deck](https://github.com/Julusian/node-elgato-stream-deck))
 - Ajazz AKP153 (thanks to [@ZCube](https://github.com/ZCube))
 - Ajazz AKP153E (thanks to [@teras](https://github.com/teras))
+- Ajazz AKP815 (thanks to [@teras](https://github.com/teras))

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -174,6 +174,12 @@ impl AsyncStreamDeck {
         Ok(block_in_place(move || device.sleep())?)
     }
 
+    /// Make periodic events to the device, to keep it alive
+    pub async fn keep_alive(&self) -> Result<(), StreamDeckError> {
+        let device = self.device.lock().await;
+        Ok(block_in_place(move || device.keep_alive())?)
+    }
+
     /// Shutdown the device
     pub async fn shutdown(&self) -> Result<(), StreamDeckError> {
         let device = self.device.lock().await;
@@ -216,7 +222,7 @@ impl AsyncDeviceStateReader {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
                     match self.device.kind {
-                        Kind::Akp153 | Kind::Akp153E => {
+                        Kind::Akp153 | Kind::Akp153E | Kind::Akp815 => {
                             if *their {
                                 updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                                 updates.push(DeviceStateUpdate::ButtonUp(index as u8));

--- a/src/info.rs
+++ b/src/info.rs
@@ -22,16 +22,19 @@ pub const PID_STREAMDECK_PEDAL: u16 = 0x0086;
 /// Product ID of Stream Deck Plus
 pub const PID_STREAMDECK_PLUS: u16 = 0x0084;
 
-/// Vendor ID of Ajazz Stream Deck
+/// Vendor ID of Ajazz Desk Controller
 pub const AJAZZ_VENDOR_ID_1: u16 = 0x5548;
 
-/// Product ID of Ajazz Stream Deck AKP153
+/// Product ID of Ajazz AKP153 Desk Controller
 pub const PID_AJAZZ_AKP153: u16 = 0x6674;
 
-/// Vendor ID of Ajazz Stream Deck AKP153E
+/// Product ID of Ajazz AKP815 Desk Controller
+pub const PID_AJAZZ_AKP815: u16 = 0x6672;
+
+/// Vendor ID of Ajazz AKP153E Desk Controller
 pub const AJAZZ_VENDOR_ID_2: u16 = 0x0300;
 
-/// Product ID of Ajazz Stream Deck AKP153E
+/// Product ID of Ajazz AKP153E Desk Controller
 pub const PID_AJAZZ_E_AKP153E: u16 = 0x1010;
 
 const RECOGNIZED_VENDORS: &'static [u16] = &[
@@ -69,10 +72,12 @@ pub enum Kind {
     Pedal,
     /// Stream Deck Plus
     Plus,
-    /// Ajazz Stream Deck AKP153
+    /// Ajazz AKP153 Desk Controller
     Akp153,
-    /// Ajazz Stream Deck AKP153E
+    /// Ajazz AKP153E Desk Controller
     Akp153E,
+    /// Ajazz Akl982 Desk Controller
+    Akp815,
 }
 
 impl Kind {
@@ -96,6 +101,7 @@ impl Kind {
             AJAZZ_VENDOR_ID_1 | AJAZZ_VENDOR_ID_2 => match pid {
                 PID_AJAZZ_AKP153 => Some(Kind::Akp153),
                 PID_AJAZZ_E_AKP153E => Some(Kind::Akp153E),
+                PID_AJAZZ_AKP815 => Some(Kind::Akp815),
                 _ => None
             }
             
@@ -117,6 +123,7 @@ impl Kind {
             Kind::Pedal => PID_STREAMDECK_PEDAL,
             Kind::Plus => PID_STREAMDECK_PLUS,
             Kind::Akp153 => PID_AJAZZ_AKP153,
+            Kind::Akp815 => PID_AJAZZ_AKP815,
             Kind::Akp153E => PID_AJAZZ_E_AKP153E,
         }
     }
@@ -135,6 +142,7 @@ impl Kind {
             Kind::Pedal => ELGATO_VENDOR_ID,
             Kind::Plus => ELGATO_VENDOR_ID,
             Kind::Akp153 => AJAZZ_VENDOR_ID_1,
+            Kind::Akp815 => AJAZZ_VENDOR_ID_1,
             Kind::Akp153E => AJAZZ_VENDOR_ID_2,
         }
     }
@@ -148,6 +156,7 @@ impl Kind {
             Kind::Pedal => 3,
             Kind::Neo | Kind::Plus => 8,
             Kind::Akp153 | Kind::Akp153E => 15 + 3,
+            Kind::Akp815 => 15,
         }
     }
 
@@ -160,6 +169,7 @@ impl Kind {
             Kind::Pedal => 1,
             Kind::Neo | Kind::Plus => 2,
             Kind::Akp153 | Kind::Akp153E => 3,
+            Kind::Akp815 =>5,
         }
     }
 
@@ -171,8 +181,8 @@ impl Kind {
             Kind::Xl | Kind::XlV2 => 8,
             Kind::Pedal => 3,
             Kind::Neo | Kind::Plus => 4,
-            Kind::Akp153 => 6,
-            Kind::Akp153E => 6,
+            Kind::Akp153 | Kind::Akp153E => 6,
+            Kind::Akp815 => 3,
         }
     }
 
@@ -197,7 +207,8 @@ impl Kind {
         match self {
             Kind::Plus => Some((800, 100)),
             Kind::Neo => Some((248, 58)),
-            Kind::Akp153 | Kind::Akp153E => Some((854, 480)), // logo
+            Kind::Akp153 | Kind::Akp153E => Some((854, 480)),
+            Kind::Akp815 => Some((800, 480)),
             _ => None,
         }
     }
@@ -260,6 +271,13 @@ impl Kind {
                 size: (85, 85),
                 rotation: ImageRotation::Rot90,
                 mirror: ImageMirroring::Both,
+            },
+
+            Kind::Akp815 => ImageFormat {
+                mode: ImageMode::JPEG,
+                size: (100, 100),
+                rotation: ImageRotation::Rot180,
+                mirror: ImageMirroring::None,
             },
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,14 +65,6 @@ pub fn extract_str(bytes: &[u8]) -> Result<String, Utf8Error> {
 }
 
 /*
- Ajazz's key index
- -----------------------------
-| 0d | 0a | 07 | 04 | 01 | 10 |
-|----|----|----|----|----|----|
-| 0e | 0b | 08 | 05 | 02 | 11 |
-|----|----|----|----|----|----|
-| 0f | 0c | 09 | 06 | 03 | 12 |
- -----------------------------
  Elgato's key index
  -----------------------------
 | 01 | 02 | 03 | 04 | 05 | 06 |
@@ -81,30 +73,62 @@ pub fn extract_str(bytes: &[u8]) -> Result<String, Utf8Error> {
 |----|----|----|----|----|----|
 | 13 | 14 | 15 | 16 | 17 | 18 |
  -----------------------------
+
+ Ajazz's AKP153(E) key index
+ -----------------------------
+| 0d | 0a | 07 | 04 | 01 | 10 |
+|----|----|----|----|----|----|
+| 0e | 0b | 08 | 05 | 02 | 11 |
+|----|----|----|----|----|----|
+| 0f | 0c | 09 | 06 | 03 | 12 |
+ -----------------------------
+
+ Ajazz's AKP815 key index
+  --------------
+ | 0f | 0e | 0d |
+ |----|----|----|
+ | 0c | 0b | 0a |
+ |----|----|----|
+ | 09 | 08 | 07 |
+ |----|----|----|
+ | 06 | 05 | 04 |
+ |----|----|----|
+ | 03 | 02 | 01 |
+  --------------
+
 */
 
 /// Converts Elgato key index to Ajazz key index
-pub fn elgato_to_ajazz(kind: &Kind, key: u8) -> u8 {
+pub fn elgato153_to_ajazz(kind: &Kind, key: u8) -> u8 {
     if key < kind.key_count() {
-        return [12, 9, 6, 3, 0, 15, 13, 10, 7, 4, 1, 16, 14, 11, 8, 5, 2, 17][key as usize];
+        [12, 9, 6, 3, 0, 15, 13, 10, 7, 4, 1, 16, 14, 11, 8, 5, 2, 17][key as usize]
     } else {
-        return key;
+        key
     }
 }
 
 /// Converts Ajazz key index to Elgato key index
-pub fn ajazz_to_elgato_input(kind: &Kind, key: u8) -> u8 {
+pub fn ajazz153_to_elgato_input(kind: &Kind, key: u8) -> u8 {
     if key < kind.key_count() {
-        return [4, 10, 16, 3, 9, 15, 2, 8, 14, 1, 7, 13, 0, 6, 12, 5, 11, 17][key as usize];
+        [4, 10, 16, 3, 9, 15, 2, 8, 14, 1, 7, 13, 0, 6, 12, 5, 11, 17][key as usize]
     } else {
-        return key;
+        key
+    }
+}
+
+/// Make last key index first, and first key index last
+pub fn inverse_key_index(kind: &Kind, key: u8) -> u8 {
+    if key < kind.key_count() {
+        kind.key_count() - 1 - key
+    } else {
+        key
     }
 }
 
 /// Flips key index horizontally, for use with Original v1 Stream Deck
 pub fn flip_key_index(kind: &Kind, key: u8) -> u8 {
     let col = key % kind.column_count();
-    return (key - col) + ((kind.column_count() - 1) - col);
+    (key - col) + ((kind.column_count() - 1) - col)
 }
 
 /// Reads button states, empty vector if no data
@@ -114,7 +138,7 @@ pub fn read_button_states(kind: &Kind, states: &Vec<u8>) -> Vec<bool> {
     }
 
     match kind {
-        Kind::Akp153 | Kind::Akp153E => {
+        Kind::Akp153 | Kind::Akp153E | Kind::Akp815 => {
             let mut bools = vec![];
 
             for i in 0..kind.key_count() {


### PR DESCRIPTION
Here is a patch for my brand new [Ajazz Akp815](https://ajazzbrand.com/products/ajazz-akp815-keyboard) device. This is a rather cheap device which would be my ideal keyboard (if the key delay wasn't that bad).

Fortunately the protocol was more or less the same. I also fixed some minor errors in the previous protocol, especially during initialization and shutdown.

One more thing: the official application "ticks" the device every second or so. I haven't seen any functional difference, whether this "**keep_alive**" event is sent or not. To be fully compatible though, I included in the API. If you have more questions, please ask me.