### PR TITLE
Fix writing to Ajazz devices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ impl StreamDeck {
                 self.set_brightness(100)?;
                 self.clear_button_image(0xff)?;
                 Ok(())
-            },
+            }
 
             _ => {
                 let mut buf = vec![0x03, 0x02];
@@ -695,9 +695,6 @@ impl StreamDeck {
             let this_length = bytes_remaining.min(image_report_payload_length);
             let bytes_sent = page_number * image_report_payload_length;
 
-            /* TODO: Should this be hardcoded, since it is only for the chinese devices
-                    or should this be done differently?
-            */
             // Create buffer with Report ID as first byte
             let mut buf: Vec<u8> = vec![0x00];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,12 +220,12 @@ impl StreamDeck {
         self.initialized.store(true, Ordering::Release);
         match self.kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x44, 0x49, 0x53];
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x44, 0x49, 0x53];
+                buf.extend(vec![0u8; 513 - buf.len()]);
                 write_data(&self.device, buf.as_slice())?;
 
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x4c, 0x49, 0x47, 0x00, 0x00, 0x00, 0x00];
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x4c, 0x49, 0x47, 0x00, 0x00, 0x00, 0x00];
+                buf.extend(vec![0u8; 513 - buf.len()]);
                 write_data(&self.device, buf.as_slice())?;
             }
 
@@ -337,9 +337,9 @@ impl StreamDeck {
             }
 
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x4c, 0x49, 0x47, 0x00, 0x00, percent];
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x4c, 0x49, 0x47, 0x00, 0x00, percent];
 
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                buf.extend(vec![0u8; 513 - buf.len()]);
 
                 write_data(&self.device, buf.as_slice())?;
 
@@ -378,6 +378,7 @@ impl StreamDeck {
         match self.kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
                 let mut buf = vec![
+                    0x00,
                     0x43,
                     0x52,
                     0x54,
@@ -393,7 +394,7 @@ impl StreamDeck {
                     key + 1,
                 ];
 
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                buf.extend(vec![0u8; 513 - buf.len()]);
 
                 write_data(&self.device, buf.as_slice())?;
             }
@@ -409,7 +410,7 @@ impl StreamDeck {
 
                 Kind::Mini | Kind::MiniMk2 => vec![0x02, 0x01, page_number as u8, 0, if last_package { 1 } else { 0 }, key + 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 
-                Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => vec![],
+                Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => vec![0x00],
 
                 _ => vec![
                     0x02,
@@ -556,9 +557,9 @@ impl StreamDeck {
                     elgato_to_ajazz153(&self.kind, key)
                 };
 
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x43, 0x4c, 0x45, 0x00, 0x00, 0x00, if key == 0xff { 0xff } else { key + 1 }];
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x43, 0x4c, 0x45, 0x00, 0x00, 0x00, if key == 0xff { 0xff } else { key + 1 }];
 
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                buf.extend(vec![0u8; 513 - buf.len()]);
 
                 write_data(&self.device, buf.as_slice())?;
 
@@ -605,9 +606,9 @@ impl StreamDeck {
             return Err(StreamDeckError::UnsupportedOperation);
         }
         // 854 * 480 * 3
-        let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x4c, 0x4f, 0x47, 0x00, 0x12, 0xc3, 0xc0, 0x01];
+        let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x4c, 0x4f, 0x47, 0x00, 0x12, 0xc3, 0xc0, 0x01];
 
-        buf.extend(vec![0u8; 512 - buf.len()]);
+        buf.extend(vec![0u8; 513 - buf.len()]);
 
         write_data(&self.device, buf.as_slice())?;
 
@@ -672,13 +673,13 @@ impl StreamDeck {
 
         let image_report_length = match self.kind {
             Kind::Original => 8191,
-            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 512,
+            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 513,
             _ => 1024,
         };
 
         let image_report_header_length = match self.kind {
             Kind::Original | Kind::Mini | Kind::MiniMk2 => 16,
-            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 0,
+            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 1,
             _ => 8,
         };
 
@@ -694,9 +695,13 @@ impl StreamDeck {
             let this_length = bytes_remaining.min(image_report_payload_length);
             let bytes_sent = page_number * image_report_payload_length;
 
-            // Selecting header based on device
-            let mut buf: Vec<u8> = vec![];
+            /* TODO: Should this be hardcoded, since it is only for the chinese devices
+                    or should this be done differently?
+            */
+            // Create buffer with Report ID as first byte
+            let mut buf: Vec<u8> = vec![0x00];
 
+            // Selecting header based on device
             buf.extend(&image_data[bytes_sent..bytes_sent + this_length]);
 
             // Adding padding
@@ -732,9 +737,9 @@ impl StreamDeck {
         self.initialize()?;
         match self.kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x48, 0x41, 0x4e];
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x48, 0x41, 0x4e];
 
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                buf.extend(vec![0u8; 513 - buf.len()]);
 
                 write_data(&self.device, buf.as_slice())?;
 
@@ -750,8 +755,8 @@ impl StreamDeck {
         self.initialize()?;
         match self.kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x43, 0x4F, 0x4E, 0x4E, 0x45, 0x43, 0x54];
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x43, 0x4F, 0x4E, 0x4E, 0x45, 0x43, 0x54];
+                buf.extend(vec![0u8; 513 - buf.len()]);
                 write_data(&self.device, buf.as_slice())?;
                 Ok(())
             }
@@ -765,12 +770,12 @@ impl StreamDeck {
         self.initialize()?;
         match self.kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 => {
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x43, 0x4c, 0x45, 0x00, 0x00, 0x44, 0x43];
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x43, 0x4c, 0x45, 0x00, 0x00, 0x44, 0x43];
+                buf.extend(vec![0u8; 513 - buf.len()]);
                 write_data(&self.device, buf.as_slice())?;
 
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x48, 0x41, 0x4E];
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x48, 0x41, 0x4E];
+                buf.extend(vec![0u8; 513 - buf.len()]);
                 write_data(&self.device, buf.as_slice())?;
 
                 Ok(())
@@ -794,9 +799,9 @@ impl StreamDeck {
 
         match self.kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
-                let mut buf = vec![0x43, 0x52, 0x54, 0x00, 0x00, 0x53, 0x54, 0x50];
+                let mut buf = vec![0x00, 0x43, 0x52, 0x54, 0x00, 0x00, 0x53, 0x54, 0x50];
 
-                buf.extend(vec![0u8; 512 - buf.len()]);
+                buf.extend(vec![0u8; 513 - buf.len()]);
 
                 write_data(&self.device, buf.as_slice())?;
             }
@@ -863,13 +868,13 @@ impl WriteImageParameters {
     pub fn for_key(kind: Kind, image_data_len: usize) -> Self {
         let image_report_length = match kind {
             Kind::Original => 8191,
-            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 512,
+            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 513,
             _ => 1024,
         };
 
         let image_report_header_length = match kind {
             Kind::Original | Kind::Mini | Kind::MiniMk2 => 16,
-            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 0,
+            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => 1,
             _ => 8,
         };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,14 +37,7 @@ pub fn read_data(device: &HidDevice, length: usize, timeout: Option<Duration>) -
 
 /// Writes data to [HidDevice]
 pub fn write_data(device: &HidDevice, payload: &[u8]) -> Result<usize, HidError> {
-    if cfg!(windows) || payload[0] != 0 {
-        device.write(payload)
-    } else {
-        let mut buf = vec![0u8; payload.len() + 1];
-        buf[0] = 0;
-        buf[1..].copy_from_slice(payload);
-        device.write(buf.as_slice())
-    }
+    device.write(payload)
 }
 
 /// Extracts string from byte array, removing \0 symbols


### PR DESCRIPTION
Issue #25 
hidapi write requires the first byte to be report id. In the current code this was always done on Elgato devices, but only done on Linux for the Ajazz (and Mirabox or whatever) devices. 
This pull request changes write_data to write only the payload, with the caller responsible for adding the report id byte (as it was done on Elgato devices)

TODO:

- I need to test it more
- ~Something's wrong, simple example does not work fully (with image writing I think)~

Not sure about:

- I think the length needs to be 513 (512 as intended, +1 for report id), hopefully someone confirms this
- Image writing part - it has no headers and previous code had a check for 0x00 byte, for which it didn't add a report id even under linux. I am not sure if this was really intended, as in theory it would remove the first byte, which should lead to image corruption when the first byte is intended to be 0x00.

Will not fix:
- Firmware version on Windows. This should be a separate pull request. I managed to get it working with rusb, but I'm not sure how to get it working with hidapi.