### PR TITLE
Added support for Ajazz AKP03R

### DIFF
--- a/40-streamdeck.rules
+++ b/40-streamdeck.rules
@@ -11,6 +11,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="009a", MODE="0660", 
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1003", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1020", MODE="0660", GROUP="plugdev"
 
@@ -27,6 +28,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1003", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1020", MODE="0660", GROUP="plugdev"
 
@@ -43,6 +45,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1003", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1020", MODE="0660", GROUP="plugdev"
 
@@ -59,5 +62,6 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6672", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1003", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1020", MODE="0660", GROUP="plugdev"

--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ As it stands, this library should support the following devices:
 - Ajazz AKP153E (thanks to [@teras](https://github.com/teras))
 - Ajazz AKP153R (thanks to [@teras](https://github.com/teras), [@damnkrat](https://github.com/damnkrat) and [@4ndv](https://github.com/4ndv))
 - Ajazz AKP815 (thanks to [@teras](https://github.com/teras))
+- Ajazz AKP03R (thanks to [@4ndv](https://github.com/4ndv))
 - MiraBox HSV293S (thanks to [@czyz](https://github.com/czyz))

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -222,7 +222,7 @@ impl AsyncDeviceStateReader {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
                     match self.device.kind {
-                        Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
+                        Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::Akp03R | Kind::MiraBoxHSV293S => {
                             if *their {
                                 updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                                 updates.push(DeviceStateUpdate::ButtonUp(index as u8));
@@ -253,11 +253,21 @@ impl AsyncDeviceStateReader {
 
             StreamDeckInput::EncoderStateChange(encoders) => {
                 for (index, (their, mine)) in zip(encoders.iter(), my_states.encoders.iter()).enumerate() {
-                    if *their != *mine {
-                        if *their {
-                            updates.push(DeviceStateUpdate::EncoderDown(index as u8));
-                        } else {
-                            updates.push(DeviceStateUpdate::EncoderUp(index as u8));
+                    match self.device.kind {
+                        Kind::Akp03R => {
+                            if *their {
+                                updates.push(DeviceStateUpdate::EncoderDown(index as u8));
+                                updates.push(DeviceStateUpdate::EncoderUp(index as u8));
+                            }
+                        }
+                        _ => {
+                            if *their != *mine {
+                                if *their {
+                                    updates.push(DeviceStateUpdate::EncoderDown(index as u8));
+                                } else {
+                                    updates.push(DeviceStateUpdate::EncoderUp(index as u8));
+                                }
+                            }
                         }
                     }
                 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -43,6 +43,9 @@ pub const PID_AJAZZ_AKP153E: u16 = 0x1010;
 /// Product ID of Ajazz AKP153R Desk Controller
 pub const PID_AJAZZ_AKP153R: u16 = 0x1020;
 
+/// Product ID of Ajazz AKP03R Desk Controller
+pub const PID_AJAZZ_AKP03R: u16 = 0x1003;
+
 const RECOGNIZED_VENDORS: [u16; 3] = [ELGATO_VENDOR_ID, AJAZZ_VENDOR_ID_1, AJAZZ_VENDOR_ID_2];
 
 /// Returns true for vendors IDs that are recognized by the library
@@ -81,6 +84,8 @@ pub enum Kind {
     Akp153R,
     /// Ajazz AKP815 Desk Controller
     Akp815,
+    /// Ajazz AKP03R Desk Controller
+    Akp03R,
     /// MiraBox HSV293S
     MiraBoxHSV293S,
 }
@@ -108,6 +113,7 @@ impl Kind {
                 PID_AJAZZ_AKP153E => Some(Kind::Akp153E),
                 PID_AJAZZ_AKP153R => Some(Kind::Akp153R),
                 PID_AJAZZ_AKP815 => Some(Kind::Akp815),
+                PID_AJAZZ_AKP03R => Some(Kind::Akp03R),
                 PID_MIRABOX_HSV293S => Some(Kind::MiraBoxHSV293S),
                 _ => None,
             },
@@ -133,6 +139,7 @@ impl Kind {
             Kind::Akp815 => PID_AJAZZ_AKP815,
             Kind::Akp153E => PID_AJAZZ_AKP153E,
             Kind::Akp153R => PID_AJAZZ_AKP153R,
+            Kind::Akp03R => PID_AJAZZ_AKP03R,
             Kind::MiraBoxHSV293S => PID_MIRABOX_HSV293S,
         }
     }
@@ -154,6 +161,7 @@ impl Kind {
             Kind::Akp815 => AJAZZ_VENDOR_ID_1,
             Kind::Akp153E => AJAZZ_VENDOR_ID_2,
             Kind::Akp153R => AJAZZ_VENDOR_ID_2,
+            Kind::Akp03R => AJAZZ_VENDOR_ID_2,
             Kind::MiraBoxHSV293S => AJAZZ_VENDOR_ID_1,
         }
     }
@@ -168,6 +176,7 @@ impl Kind {
             Kind::Neo | Kind::Plus => 8,
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 15 + 3,
             Kind::Akp815 => 15,
+            Kind::Akp03R => 6 + 3,
         }
     }
 
@@ -181,6 +190,7 @@ impl Kind {
             Kind::Neo | Kind::Plus => 2,
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 3,
             Kind::Akp815 => 5,
+            Kind::Akp03R => 3,
         }
     }
 
@@ -194,6 +204,7 @@ impl Kind {
             Kind::Neo | Kind::Plus => 4,
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 6,
             Kind::Akp815 => 3,
+            Kind::Akp03R => 3,
         }
     }
 
@@ -201,6 +212,7 @@ impl Kind {
     pub fn encoder_count(&self) -> u8 {
         match self {
             Kind::Plus => 4,
+            Kind::Akp03R => 3,
             _ => 0,
         }
     }
@@ -285,6 +297,13 @@ impl Kind {
                 mode: ImageMode::JPEG,
                 size: (100, 100),
                 rotation: ImageRotation::Rot180,
+                mirror: ImageMirroring::None,
+            },
+
+            Kind::Akp03R => ImageFormat {
+                mode: ImageMode::JPEG,
+                size: (64, 64),
+                rotation: ImageRotation::Rot0,
                 mirror: ImageMirroring::None,
             },
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -112,6 +112,16 @@ pub fn flip_key_index(kind: &Kind, key: u8) -> u8 {
     (key - col) + ((kind.column_count() - 1) - col)
 }
 
+/// Extends buffer up to required packet length
+pub fn ajazz_extend_packet(kind: &Kind, buf: &mut Vec<u8>) {
+    let length = match kind {
+        Kind::Akp03R => 1025,
+        _ => 513,
+    };
+
+    buf.extend(vec![0u8; length - buf.len()]);
+}
+
 /// Reads button states, empty vector if no data
 pub fn read_button_states(kind: &Kind, states: &[u8]) -> Vec<bool> {
     if states[0] == 0 {
@@ -119,7 +129,7 @@ pub fn read_button_states(kind: &Kind, states: &[u8]) -> Vec<bool> {
     }
 
     match kind {
-        Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => {
+        Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::Akp03R | Kind::MiraBoxHSV293S => {
             let mut bools = vec![];
 
             for i in 0..kind.key_count() {
@@ -178,4 +188,71 @@ pub fn read_encoder_input(kind: &Kind, data: &[u8]) -> Result<StreamDeckInput, S
 
         _ => Err(StreamDeckError::BadData),
     }
+}
+
+/// Read inputs from Ajazz AKP03
+pub fn ajazz03_read_input(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+    match input {
+        (0..=6) | 0x25 | 0x30 | 0x31 => ajazz03_read_button_press(kind, input),
+        0x90 | 0x91 | 0x50 | 0x51 | 0x60 | 0x61 => ajazz03_read_encoder_value(kind, input),
+        0x33 | 0x34 | 0x35 => ajazz03_read_encoder_press(kind, input),
+        _ => Err(StreamDeckError::BadData),
+    }
+}
+
+fn ajazz03_read_button_press(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+    let mut button_states = vec![0x01];
+    button_states.extend(vec![0u8; (kind.key_count() + 1) as usize]);
+
+    if input == 0 {
+        return Ok(StreamDeckInput::ButtonStateChange(read_button_states(kind, &button_states)));
+    }
+
+    let pressed_index: usize = match input {
+        // Six buttons with displays
+        (1..=6) => input as usize,
+        // Three buttons without displays
+        0x25 => 7,
+        0x30 => 8,
+        0x31 => 9,
+        _ => return Err(StreamDeckError::BadData),
+    };
+
+    button_states[pressed_index] = 0x1u8;
+
+    Ok(StreamDeckInput::ButtonStateChange(read_button_states(kind, &button_states)))
+}
+
+fn ajazz03_read_encoder_value(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+    let mut encoder_values = vec![0i8; kind.encoder_count() as usize];
+
+    let (encoder, value): (usize, i8) = match input {
+        // Left encoder
+        0x90 => (0, -1),
+        0x91 => (0, 1),
+        // Middle (top) encoder
+        0x50 => (1, -1),
+        0x51 => (1, 1),
+        // Right encoder
+        0x60 => (2, -1),
+        0x61 => (2, 1),
+        _ => return Err(StreamDeckError::BadData),
+    };
+
+    encoder_values[encoder] = value;
+    Ok(StreamDeckInput::EncoderTwist(encoder_values))
+}
+
+fn ajazz03_read_encoder_press(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+    let mut encoder_states = vec![false; kind.encoder_count() as usize];
+
+    let encoder: usize = match input {
+        0x33 => 0, // Left encoder
+        0x35 => 1, // Middle (top) encoder
+        0x34 => 2, // Right encoder
+        _ => return Err(StreamDeckError::BadData),
+    };
+
+    encoder_states[encoder] = true;
+    Ok(StreamDeckInput::EncoderStateChange(encoder_states))
 }


### PR DESCRIPTION
Main difference from all the other Ajazz devices is that packet length is 1024 bytes instead of 512

...and also 3 buttons without displays in the bottom of the device, so it has both pretty and boring buttons at the same time. I've mapped them just like usual buttons, but maybe it would be best to separate the two (mostly due to Stream Deck Pedal existence)

Should work the same for: AKP03, AKP03E, AKP03R, Mirabox N3, Mirabox 293N3, but I only have AKP03R, and don't know VIDs and PIDs of other devices

I'm not *very* familiar with Rust, so please tell me if there is any changes required :)