### PR TITLE
Fixed incorrect image size and clearing screen for AKP03R

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -302,7 +302,7 @@ impl Kind {
 
             Kind::Akp03R => ImageFormat {
                 mode: ImageMode::JPEG,
-                size: (64, 64),
+                size: (60, 60),
                 rotation: ImageRotation::Rot0,
                 mirror: ImageMirroring::None,
             },


### PR DESCRIPTION
Previous image size was chosen because I've found it on manufacturer's forum.

That caused issues with clearing buttons that was *very* hard to debug (for me, not very familiar with the quirks of these devices), so I extracted the image from dump between device and manufacturer's app, and it was 60x60px...