### PR TITLE
Refactor Mirabox conditions

### DIFF
--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -222,7 +222,7 @@ impl AsyncDeviceStateReader {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
                     match self.device.kind {
-                        Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxHSV293S => {
+                        kind if kind.is_mirabox() => {
                             if *their {
                                 updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                                 updates.push(DeviceStateUpdate::ButtonUp(index as u8));

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -221,27 +221,24 @@ impl AsyncDeviceStateReader {
         match input {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
-                    match self.device.kind {
-                        kind if kind.is_mirabox() => {
-                            if *their {
-                                updates.push(DeviceStateUpdate::ButtonDown(index as u8));
-                                updates.push(DeviceStateUpdate::ButtonUp(index as u8));
-                            }
+                    if self.device.kind.is_mirabox() {
+                        if *their {
+                            updates.push(DeviceStateUpdate::ButtonDown(index as u8));
+                            updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                         }
-                        _ => {
-                            if *their != *mine {
-                                if index < self.device.kind.key_count() as usize {
-                                    if *their {
-                                        updates.push(DeviceStateUpdate::ButtonDown(index as u8));
-                                    } else {
-                                        updates.push(DeviceStateUpdate::ButtonUp(index as u8));
-                                    }
+                    } else {
+                        if *their != *mine {
+                            if index < self.device.kind.key_count() as usize {
+                                if *their {
+                                    updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                                 } else {
-                                    if *their {
-                                        updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - self.device.kind.key_count()));
-                                    } else {
-                                        updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - self.device.kind.key_count()));
-                                    }
+                                    updates.push(DeviceStateUpdate::ButtonUp(index as u8));
+                                }
+                            } else {
+                                if *their {
+                                    updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - self.device.kind.key_count()));
+                                } else {
+                                    updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - self.device.kind.key_count()));
                                 }
                             }
                         }

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -226,21 +226,17 @@ impl AsyncDeviceStateReader {
                             updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                         }
-                    } else {
-                        if *their != *mine {
-                            if index < self.device.kind.key_count() as usize {
-                                if *their {
-                                    updates.push(DeviceStateUpdate::ButtonDown(index as u8));
-                                } else {
-                                    updates.push(DeviceStateUpdate::ButtonUp(index as u8));
-                                }
+                    } else if *their != *mine {
+                        if index < self.device.kind.key_count() as usize {
+                            if *their {
+                                updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             } else {
-                                if *their {
-                                    updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - self.device.kind.key_count()));
-                                } else {
-                                    updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - self.device.kind.key_count()));
-                                }
+                                updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                             }
+                        } else if *their {
+                            updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - self.device.kind.key_count()));
+                        } else {
+                            updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - self.device.kind.key_count()));
                         }
                     }
                 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -450,6 +450,27 @@ impl Kind {
             _ => vec![],
         }
     }
+
+    /// Returns true for Mirabox devices with 512 byte packet length
+    pub fn is_mirabox_v1(&self) -> bool {
+        match self {
+            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true for Mirabox devices with 1024 byte packet length
+    pub fn is_mirabox_v2(&self) -> bool {
+        match self {
+            Kind::Akp03E | Kind::Akp03R => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true for Mirabox devices
+    pub fn is_mirabox(&self) -> bool {
+        self.is_mirabox_v1() || self.is_mirabox_v2()
+    }
 }
 
 /// Image format used by the Stream Deck

--- a/src/info.rs
+++ b/src/info.rs
@@ -453,18 +453,12 @@ impl Kind {
 
     /// Returns true for Mirabox devices with 512 byte packet length
     pub fn is_mirabox_v1(&self) -> bool {
-        match self {
-            Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S => true,
-            _ => false,
-        }
+        matches!(self, Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::MiraBoxHSV293S)
     }
 
     /// Returns true for Mirabox devices with 1024 byte packet length
     pub fn is_mirabox_v2(&self) -> bool {
-        match self {
-            Kind::Akp03E | Kind::Akp03R => true,
-            _ => false,
-        }
+        matches!(self, Kind::Akp03E | Kind::Akp03R)
     }
 
     /// Returns true for Mirabox devices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1037,27 +1037,24 @@ impl DeviceStateReader {
         match input {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
-                    match self.device.kind {
-                        kind if kind.is_mirabox() => {
-                            if *their {
-                                updates.push(DeviceStateUpdate::ButtonDown(index as u8));
-                                updates.push(DeviceStateUpdate::ButtonUp(index as u8));
-                            }
+                    if self.device.kind.is_mirabox() {
+                        if *their {
+                            updates.push(DeviceStateUpdate::ButtonDown(index as u8));
+                            updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                         }
-                        _ => {
-                            if their != mine {
-                                let key_count = self.device.kind.key_count();
-                                if index < key_count as usize {
-                                    if *their {
-                                        updates.push(DeviceStateUpdate::ButtonDown(index as u8));
-                                    } else {
-                                        updates.push(DeviceStateUpdate::ButtonUp(index as u8));
-                                    }
-                                } else if *their {
-                                    updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - key_count));
+                    } else {
+                        if their != mine {
+                            let key_count = self.device.kind.key_count();
+                            if index < key_count as usize {
+                                if *their {
+                                    updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                                 } else {
-                                    updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - key_count));
+                                    updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                                 }
+                            } else if *their {
+                                updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - key_count));
+                            } else {
+                                updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - key_count));
                             }
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,10 +573,10 @@ impl StreamDeck {
 
             write_data(&self.device, buf.as_slice())?;
 
-            return Ok(());
+            Ok(())
+        } else {
+            Ok(self.send_image(key, &self.kind.blank_image())?)
         }
-
-        Ok(self.send_image(key, &self.kind.blank_image())?)
     }
 
     /// Sets blank images to every button, changes must be flushed with `.flush()` before

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1042,20 +1042,18 @@ impl DeviceStateReader {
                             updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                         }
-                    } else {
-                        if their != mine {
-                            let key_count = self.device.kind.key_count();
-                            if index < key_count as usize {
-                                if *their {
-                                    updates.push(DeviceStateUpdate::ButtonDown(index as u8));
-                                } else {
-                                    updates.push(DeviceStateUpdate::ButtonUp(index as u8));
-                                }
-                            } else if *their {
-                                updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - key_count));
+                    } else if their != mine {
+                        let key_count = self.device.kind.key_count();
+                        if index < key_count as usize {
+                            if *their {
+                                updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             } else {
-                                updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - key_count));
+                                updates.push(DeviceStateUpdate::ButtonUp(index as u8));
                             }
+                        } else if *their {
+                            updates.push(DeviceStateUpdate::TouchPointDown(index as u8 - key_count));
+                        } else {
+                            updates.push(DeviceStateUpdate::TouchPointUp(index as u8 - key_count));
                         }
                     }
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -115,7 +115,7 @@ pub fn flip_key_index(kind: &Kind, key: u8) -> u8 {
 /// Extends buffer up to required packet length
 pub fn ajazz_extend_packet(kind: &Kind, buf: &mut Vec<u8>) {
     let length = match kind {
-        Kind::Akp03E | Kind::Akp03R => 1025,
+        kind if kind.is_mirabox_v2() => 1025,
         _ => 513,
     };
 
@@ -129,7 +129,7 @@ pub fn read_button_states(kind: &Kind, states: &[u8]) -> Vec<bool> {
     }
 
     match kind {
-        Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::Akp815 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxHSV293S => {
+        kind if kind.is_mirabox() => {
             let mut bools = vec![];
 
             for i in 0..kind.key_count() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,10 +114,7 @@ pub fn flip_key_index(kind: &Kind, key: u8) -> u8 {
 
 /// Extends buffer up to required packet length
 pub fn ajazz_extend_packet(kind: &Kind, buf: &mut Vec<u8>) {
-    let length = match kind {
-        kind if kind.is_mirabox_v2() => 1025,
-        _ => 513,
-    };
+    let length = if kind.is_mirabox_v2() { 1025 } else { 513 };
 
     buf.extend(vec![0u8; length - buf.len()]);
 }


### PR DESCRIPTION
Introduced three new functions as discussed in #33, for dealing with Mirabox conditions once and (hopefully) for all

Touched couple other places, but nothing seems to break, tested with AKP153R ("v1" device) and AKP03R ("v2" device)