### PR TITLE
Adding support for Akp05E

### DIFF
--- a/40-streamdeck.rules
+++ b/40-streamdeck.rules
@@ -17,6 +17,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1003", MODE="0660", 
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1020", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="3002", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="3004", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="6603", ATTR{idProduct}=="1003", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE="0660", TAG+="uaccess", GROUP="plugdev"
@@ -38,6 +39,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1003", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1020", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="3002", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="3004", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="6603", ATTRS{idProduct}=="1003", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0060", MODE="0660", TAG+="uaccess", GROUP="plugdev"
@@ -59,6 +61,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1020", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="3002", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="3004", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="6603", ATTR{idProduct}=="1003", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE="0660", TAG+="uaccess", GROUP="plugdev"
@@ -80,4 +83,5 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1020", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="3002", MODE="0660", TAG+="uaccess", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="3004", MODE="0660", TAG+="uaccess", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="6603", ATTRS{idProduct}=="1003", MODE="0660", TAG+="uaccess", GROUP="plugdev"

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -221,7 +221,7 @@ impl AsyncDeviceStateReader {
         match input {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
-                    if self.device.kind.is_mirabox() {
+                    if self.device.kind.is_mirabox() && self.device.kind != Kind::Akp05E {
                         if *their {
                             updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             updates.push(DeviceStateUpdate::ButtonUp(index as u8));

--- a/src/info.rs
+++ b/src/info.rs
@@ -290,7 +290,7 @@ impl Kind {
             Kind::Neo => Some((248, 58)),
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => Some((854, 480)),
             Kind::Akp815 => Some((800, 480)),
-            Kind::Akp05EB => Some((800, 480)),
+            Kind::Akp05EB => Some((800, 100)),
             Kind::MiraBoxDK0108D => Some((800, 480)),
             _ => None,
         }
@@ -400,6 +400,12 @@ impl Kind {
                 mirror: ImageMirroring::None,
             }),
             Kind::Plus => Some(ImageFormat {
+                mode: ImageMode::JPEG,
+                size: (800, 100),
+                rotation: ImageRotation::Rot0,
+                mirror: ImageMirroring::None,
+            }),
+            Kind::Akp05EB => Some(ImageFormat {
                 mode: ImageMode::JPEG,
                 size: (800, 100),
                 rotation: ImageRotation::Rot0,

--- a/src/info.rs
+++ b/src/info.rs
@@ -55,6 +55,9 @@ pub const PID_AJAZZ_AKP03E: u16 = 0x3002;
 /// Product ID of Ajazz AKP03R
 pub const PID_AJAZZ_AKP03R: u16 = 0x1003;
 
+/// Product ID of Ajazz AKP05EB
+pub const PID_AJAZZ_AKP05EB: u16 = 0x3004;
+
 /// A Mirabox vendor ID
 pub const MIRABOX_VENDOR_ID_3: u16 = 0x6603;
 
@@ -105,6 +108,8 @@ pub enum Kind {
     Akp03E,
     /// Ajazz AKP03R
     Akp03R,
+    /// Ajazz AKP05EB
+    Akp05EB,
     /// MiraBox HSV293S
     MiraBoxHSV293S,
     /// MiraBox DK0108D
@@ -145,6 +150,7 @@ impl Kind {
                 PID_AJAZZ_AKP03 => Some(Kind::Akp03),
                 PID_AJAZZ_AKP03E => Some(Kind::Akp03E),
                 PID_AJAZZ_AKP03R => Some(Kind::Akp03R),
+                PID_AJAZZ_AKP05EB => Some(Kind::Akp05EB),
                 _ => None,
             },
 
@@ -177,6 +183,7 @@ impl Kind {
             Kind::Akp03 => PID_AJAZZ_AKP03,
             Kind::Akp03E => PID_AJAZZ_AKP03E,
             Kind::Akp03R => PID_AJAZZ_AKP03R,
+            Kind::Akp05EB => PID_AJAZZ_AKP05EB,
             Kind::MiraBoxHSV293S => PID_MIRABOX_HSV293S,
             Kind::MiraBoxDK0108D => PID_MIRABOX_DK0108D,
             Kind::MiraBoxN3EN => PID_MIRABOX_N3EN,
@@ -203,6 +210,7 @@ impl Kind {
             Kind::Akp03 => MIRABOX_VENDOR_ID_2,
             Kind::Akp03E => MIRABOX_VENDOR_ID_2,
             Kind::Akp03R => MIRABOX_VENDOR_ID_2,
+            Kind::Akp05EB => MIRABOX_VENDOR_ID_2,
             Kind::MiraBoxHSV293S => MIRABOX_VENDOR_ID_1,
             Kind::MiraBoxDK0108D => MIRABOX_VENDOR_ID_1,
             Kind::MiraBoxN3EN => MIRABOX_VENDOR_ID_3,
@@ -220,6 +228,7 @@ impl Kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 15 + 3,
             Kind::Akp815 => 15,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 6 + 3,
+            Kind::Akp05EB => 10,
             Kind::MiraBoxDK0108D => 12,
         }
     }
@@ -235,6 +244,7 @@ impl Kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 3,
             Kind::Akp815 => 5,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 3,
+            Kind::Akp05EB => 2,
             Kind::MiraBoxDK0108D => 3,
         }
     }
@@ -250,6 +260,7 @@ impl Kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 6,
             Kind::Akp815 => 3,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 3,
+            Kind::Akp05EB => 5,
             Kind::MiraBoxDK0108D => 4,
         }
     }
@@ -259,6 +270,7 @@ impl Kind {
         match self {
             Kind::Plus => 4,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 3,
+            Kind::Akp05EB => 4,
             _ => 0,
         }
     }
@@ -278,6 +290,7 @@ impl Kind {
             Kind::Neo => Some((248, 58)),
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => Some((854, 480)),
             Kind::Akp815 => Some((800, 480)),
+            Kind::Akp05EB => Some((800, 480)),
             Kind::MiraBoxDK0108D => Some((800, 480)),
             _ => None,
         }
@@ -351,6 +364,13 @@ impl Kind {
                 mode: ImageMode::JPEG,
                 size: (60, 60),
                 rotation: ImageRotation::Rot0,
+                mirror: ImageMirroring::None,
+            },
+
+            Kind::Akp05EB => ImageFormat {
+                mode: ImageMode::JPEG,
+                size: (120, 120),
+                rotation: ImageRotation::Rot180,
                 mirror: ImageMirroring::None,
             },
 
@@ -511,7 +531,7 @@ impl Kind {
 
     /// Returns true for Mirabox devices with 1024 byte packet length
     pub fn is_mirabox_v2(&self) -> bool {
-        matches!(self, Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN)
+        matches!(self, Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::Akp05EB | Kind::MiraBoxN3EN)
     }
 
     /// Returns true for Mirabox devices

--- a/src/info.rs
+++ b/src/info.rs
@@ -56,7 +56,7 @@ pub const PID_AJAZZ_AKP03E: u16 = 0x3002;
 pub const PID_AJAZZ_AKP03R: u16 = 0x1003;
 
 /// Product ID of Ajazz AKP05EB
-pub const PID_AJAZZ_AKP05EB: u16 = 0x3004;
+pub const PID_AJAZZ_AKP05E: u16 = 0x3004;
 
 /// A Mirabox vendor ID
 pub const MIRABOX_VENDOR_ID_3: u16 = 0x6603;
@@ -109,7 +109,7 @@ pub enum Kind {
     /// Ajazz AKP03R
     Akp03R,
     /// Ajazz AKP05EB
-    Akp05EB,
+    Akp05E,
     /// MiraBox HSV293S
     MiraBoxHSV293S,
     /// MiraBox DK0108D
@@ -150,7 +150,7 @@ impl Kind {
                 PID_AJAZZ_AKP03 => Some(Kind::Akp03),
                 PID_AJAZZ_AKP03E => Some(Kind::Akp03E),
                 PID_AJAZZ_AKP03R => Some(Kind::Akp03R),
-                PID_AJAZZ_AKP05EB => Some(Kind::Akp05EB),
+                PID_AJAZZ_AKP05E => Some(Kind::Akp05E),
                 _ => None,
             },
 
@@ -183,7 +183,7 @@ impl Kind {
             Kind::Akp03 => PID_AJAZZ_AKP03,
             Kind::Akp03E => PID_AJAZZ_AKP03E,
             Kind::Akp03R => PID_AJAZZ_AKP03R,
-            Kind::Akp05EB => PID_AJAZZ_AKP05EB,
+            Kind::Akp05E => PID_AJAZZ_AKP05E,
             Kind::MiraBoxHSV293S => PID_MIRABOX_HSV293S,
             Kind::MiraBoxDK0108D => PID_MIRABOX_DK0108D,
             Kind::MiraBoxN3EN => PID_MIRABOX_N3EN,
@@ -210,7 +210,7 @@ impl Kind {
             Kind::Akp03 => MIRABOX_VENDOR_ID_2,
             Kind::Akp03E => MIRABOX_VENDOR_ID_2,
             Kind::Akp03R => MIRABOX_VENDOR_ID_2,
-            Kind::Akp05EB => MIRABOX_VENDOR_ID_2,
+            Kind::Akp05E => MIRABOX_VENDOR_ID_2,
             Kind::MiraBoxHSV293S => MIRABOX_VENDOR_ID_1,
             Kind::MiraBoxDK0108D => MIRABOX_VENDOR_ID_1,
             Kind::MiraBoxN3EN => MIRABOX_VENDOR_ID_3,
@@ -228,7 +228,7 @@ impl Kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 15 + 3,
             Kind::Akp815 => 15,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 6 + 3,
-            Kind::Akp05EB => 10,
+            Kind::Akp05E => 10,
             Kind::MiraBoxDK0108D => 12,
         }
     }
@@ -244,7 +244,7 @@ impl Kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 3,
             Kind::Akp815 => 5,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 3,
-            Kind::Akp05EB => 2,
+            Kind::Akp05E => 2,
             Kind::MiraBoxDK0108D => 3,
         }
     }
@@ -260,7 +260,7 @@ impl Kind {
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => 6,
             Kind::Akp815 => 3,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 3,
-            Kind::Akp05EB => 5,
+            Kind::Akp05E => 5,
             Kind::MiraBoxDK0108D => 4,
         }
     }
@@ -270,7 +270,7 @@ impl Kind {
         match self {
             Kind::Plus => 4,
             Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::MiraBoxN3EN => 3,
-            Kind::Akp05EB => 4,
+            Kind::Akp05E => 4,
             _ => 0,
         }
     }
@@ -290,7 +290,7 @@ impl Kind {
             Kind::Neo => Some((248, 58)),
             Kind::Akp153 | Kind::Akp153E | Kind::Akp153R | Kind::MiraBoxHSV293S => Some((854, 480)),
             Kind::Akp815 => Some((800, 480)),
-            Kind::Akp05EB => Some((800, 100)),
+            Kind::Akp05E => Some((800, 120)),
             Kind::MiraBoxDK0108D => Some((800, 480)),
             _ => None,
         }
@@ -367,7 +367,7 @@ impl Kind {
                 mirror: ImageMirroring::None,
             },
 
-            Kind::Akp05EB => ImageFormat {
+            Kind::Akp05E => ImageFormat {
                 mode: ImageMode::JPEG,
                 size: (120, 120),
                 rotation: ImageRotation::Rot180,
@@ -405,10 +405,10 @@ impl Kind {
                 rotation: ImageRotation::Rot0,
                 mirror: ImageMirroring::None,
             }),
-            Kind::Akp05EB => Some(ImageFormat {
+            Kind::Akp05E => Some(ImageFormat {
                 mode: ImageMode::JPEG,
-                size: (800, 100),
-                rotation: ImageRotation::Rot0,
+                size: (800, 120),
+                rotation: ImageRotation::Rot180,
                 mirror: ImageMirroring::None,
             }),
             _ => None,
@@ -537,7 +537,7 @@ impl Kind {
 
     /// Returns true for Mirabox devices with 1024 byte packet length
     pub fn is_mirabox_v2(&self) -> bool {
-        matches!(self, Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::Akp05EB | Kind::MiraBoxN3EN)
+        matches!(self, Kind::Akp03 | Kind::Akp03E | Kind::Akp03R | Kind::Akp05E | Kind::MiraBoxN3EN)
     }
 
     /// Returns true for Mirabox devices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ impl StreamDeck {
                 }
 
                 match self.kind {
-                    Kind::Akp05E => ajazz05_read_input(&self.kind, data[9]),
+                    Kind::Akp05E => ajazz05_read_input(&self.kind, data[9], data[10]),
                     _ => ajazz03_read_input(&self.kind, data[9]),
                 }
             }
@@ -1121,7 +1121,7 @@ impl DeviceStateReader {
         match input {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
-                    if self.device.kind.is_mirabox() {
+                    if self.device.kind.is_mirabox() && self.device.kind != Kind::Akp05E {
                         if *their {
                             updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                             updates.push(DeviceStateUpdate::ButtonUp(index as u8));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,11 @@ impl StreamDeck {
         }
 
         if self.kind.is_mirabox() {
+            let padding = match self.kind {
+                Kind::Akp05EB => 6,
+                _ => 1,
+            };
+
             let mut buf = vec![
                 0x00,
                 0x43,
@@ -409,7 +414,7 @@ impl StreamDeck {
                 0x00,
                 (image_data.len() >> 8) as u8,
                 image_data.len() as u8,
-                key + 1,
+                key + padding,
             ];
 
             mirabox_extend_packet(&self.kind, &mut buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ use image::{DynamicImage, ImageError};
 
 use crate::info::{is_vendor_familiar, Kind};
 use crate::util::{
-    ajazz03_read_input, mirabox_extend_packet, ajazz153_to_elgato_input, elgato_to_ajazz153, extract_str, flip_key_index, get_feature_report, inverse_key_index, read_button_states, read_data,
-    read_encoder_input, read_lcd_input, send_feature_report, write_data,
+    ajazz03_read_input, ajazz05_read_input, mirabox_extend_packet, ajazz153_to_elgato_input, elgato_to_ajazz153, extract_str, flip_key_index, get_feature_report, inverse_key_index,
+    read_button_states, read_data, read_encoder_input, read_lcd_input, send_feature_report, write_data,
 };
 
 /// Various information about Stream Deck devices
@@ -292,7 +292,10 @@ impl StreamDeck {
                     return Ok(StreamDeckInput::NoData);
                 }
 
-                ajazz03_read_input(&self.kind, data[9])
+                match self.kind {
+                    Kind::Akp05EB => ajazz05_read_input(&self.kind, data[9]),
+                    _ => ajazz03_read_input(&self.kind, data[9]),
+                }
             }
 
             _ => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -322,6 +322,15 @@ fn ajazz05_read_encoder_press(kind: &Kind, input: u8) -> Result<StreamDeckInput,
     Ok(StreamDeckInput::EncoderStateChange(encoder_states))
 }
 
-fn ajazz05_read_screen_press(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
-    Ok(StreamDeckInput::NoData)
+fn ajazz05_read_screen_press(_kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+    let start_x: u16 = match input {
+        0x38 => return Ok(StreamDeckInput::TouchScreenSwipe((0, 0), (800, 0))),
+        0x39 => return Ok(StreamDeckInput::TouchScreenSwipe((800, 0), (0, 0))),
+        0x40 => 0,
+        0x41 => 200,
+        0x42 => 400,
+        0x43 => 600,
+        _ => return Err(StreamDeckError::BadData),
+    };
+    Ok(StreamDeckInput::TouchScreenPress(start_x, 0))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -255,9 +255,9 @@ fn ajazz03_read_encoder_press(kind: &Kind, input: u8) -> Result<StreamDeckInput,
 }
 
 /// Read inputs from Ajazz AKP05x
-pub fn ajazz05_read_input(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+pub fn ajazz05_read_input(kind: &Kind, input: u8, state: u8) -> Result<StreamDeckInput, StreamDeckError> {
     match input {
-        (0..=10) => ajazz05_read_button_press(kind, input),
+        (0..=10) => ajazz05_read_button_press(kind, input, state),
         0xa0 | 0xa1 | 0x50 | 0x51 | 0x90 | 0x91 | 0x70 | 0x71 => ajazz05_read_encoder_value(kind, input),
         0x33 | 0x35 | 0x36 | 0x37 => ajazz05_read_encoder_press(kind, input),
         0x38 | 0x39 | 0x40 | 0x41 | 0x42 | 0x43 => ajazz05_read_screen_press(kind, input),
@@ -265,7 +265,7 @@ pub fn ajazz05_read_input(kind: &Kind, input: u8) -> Result<StreamDeckInput, Str
     }
 }
 
-fn ajazz05_read_button_press(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+fn ajazz05_read_button_press(kind: &Kind, input: u8, state: u8) -> Result<StreamDeckInput, StreamDeckError> {
     let mut button_states = vec![0x01];
     button_states.extend(vec![0u8; (kind.key_count() + 1) as usize]);
 
@@ -279,7 +279,7 @@ fn ajazz05_read_button_press(kind: &Kind, input: u8) -> Result<StreamDeckInput, 
         _ => return Err(StreamDeckError::BadData),
     };
 
-    button_states[pressed_index] = 0x1u8;
+    button_states[pressed_index] = state;
 
     Ok(StreamDeckInput::ButtonStateChange(read_button_states(kind, &button_states)))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -260,6 +260,7 @@ pub fn ajazz05_read_input(kind: &Kind, input: u8) -> Result<StreamDeckInput, Str
         (0..=10) => ajazz05_read_button_press(kind, input),
         0xa0 | 0xa1 | 0x50 | 0x51 | 0x90 | 0x91 | 0x70 | 0x71 => ajazz05_read_encoder_value(kind, input),
         0x33 | 0x35 | 0x36 | 0x37 => ajazz05_read_encoder_press(kind, input),
+        0x38 | 0x39 | 0x40 | 0x41 | 0x42 | 0x43 => ajazz05_read_screen_press(kind, input),
         _ => Err(StreamDeckError::BadData),
     }
 }
@@ -319,4 +320,8 @@ fn ajazz05_read_encoder_press(kind: &Kind, input: u8) -> Result<StreamDeckInput,
 
     encoder_states[encoder] = true;
     Ok(StreamDeckInput::EncoderStateChange(encoder_states))
+}
+
+fn ajazz05_read_screen_press(kind: &Kind, input: u8) -> Result<StreamDeckInput, StreamDeckError> {
+    Ok(StreamDeckInput::NoData)
 }


### PR DESCRIPTION
Adding support for AKP05E
[AKP05E on aliexpress](https://aliexpress.com/item/1005008488496600.html?algo_exp_id=63ce4df7-b1cd-495a-8201-6994acb53aa4-0&pdp_ext_f=%7B%22order%22%3A%2213%22%2C%22eval%22%3A%221%22%7D&pdp_npi=4%40dis!EUR!90.29!86.39!!!731.08!699.51!%402103856417447873440241806e27d3!12000045366773127!sea!FR!1837685369!X&curPageLogUid=qvyI5LHfUUZT&utparam-url=scene%3Asearch%7Cquery_from%3A)

This is a copy of streamdeck Plus.
It as:
- 10 buttons (5x2)
- 4 encoders
- 1 touchscreen

BUT:
The screen is not like on the plus and is interpreted by the firmware as the first 4 buttons (yes 4 not a typo)

the buttons index for the firmware are :

| btn | btn | btn | btn | btn |
| -- | -- | -- | -- | -- |
| 11 | 12 | 13 | 14 | 15 |
|  6 |  7 |  8 | 9 | 10 |

| touch | touch | touch | touch |
| -- | -- | -- | -- | 
|  1    |    2   |   3   |    4   |  

the buttons index for the lib are :

| btn | btn | btn | btn | btn |
| -- | -- | -- | -- | -- |
| 1 | 2 | 3 | 4 | 5 |
|  6 |  7 |  8 | 9 | 10 |

The lcd is not interpreted a buttons for the lib but send touch events.'

Everything work for now except:
- `write_lcd_fill`: i'm unable to display the full picture
- touch long press events: not sent by the device