### PR TITLE
feat: impl From<StreamDeck> for AsyncStreamDeck

### DIFF
--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -48,6 +48,16 @@ impl AsyncStreamDeck {
     }
 }
 
+impl From<StreamDeck> for AsyncStreamDeck {
+    /// Wraps an already-opened [StreamDeck], allowing the caller to control which thread performs the HID open
+    fn from(device: StreamDeck) -> AsyncStreamDeck {
+        AsyncStreamDeck {
+            kind: device.kind(),
+            device: Arc::new(Mutex::new(device)),
+        }
+    }
+}
+
 /// Instance methods of the struct
 impl AsyncStreamDeck {
     /// Returns kind of the Stream Deck


### PR DESCRIPTION
## What

Implements `From<StreamDeck> for AsyncStreamDeck`, so an already-opened synchronous `StreamDeck` can be wrapped into the async wrapper without going through `AsyncStreamDeck::connect`.

## Why

On macOS, hidapi's `IOHIDManager` is implicitly bound to the run loop of the thread that created the `HidApi`. Enumerating/opening devices from any other thread schedules IOKit sources on a foreign run loop, which can trap in CoreFoundation (`EXC_BREAKPOINT` in `__CFCheckCFInfoPACSignature` via `CFRunLoopAddSource` ← `IOHIDDeviceScheduleWithRunLoop`) — most reliably right after sleep/wake when the device set changes.

`AsyncStreamDeck::connect` runs `StreamDeck::connect` via `block_in_place` on whichever tokio worker thread is current, so an async application has no way to control which OS thread performs the HID open. Empirically, `block_in_place` does not pin to a single OS thread even on a single-worker runtime.

With this impl, an application can own the `HidApi` on one dedicated thread, enumerate and open devices there using the synchronous API, and hand the opened device (which is `Send`) to the async runtime for everything else.

## Context

Found while debugging a reproducible sleep/wake crash in [OpenDeck](https://github.com/nekename/OpenDeck) on macOS 15 (Apple Silicon). Restructuring OpenDeck's device polling around a dedicated HID thread + this impl eliminated the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)